### PR TITLE
perf: improve and optimize parallelism

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,4 +1,3 @@
 [[profile.default.overrides]]
 filter = 'test(/^(energy_test_asymptotic_*|pudelko_*)/)'
-fail-fast = false
 retries = 7

--- a/README.md
+++ b/README.md
@@ -31,10 +31,10 @@ Either run `cargo add normality` or add the crate to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-normality = "2"
+normality = "3"
 
 # To enable parallel execution for faster performance on large data:
-# normality = { version = "2", features = ["parallel"] }
+# normality = { version = "3", features = ["parallel"] }
 ```
 
 ## Example Usage

--- a/src/methods/anderson_darling.rs
+++ b/src/methods/anderson_darling.rs
@@ -63,22 +63,31 @@ pub fn anderson_darling<T: Float, I: IntoIterator<Item = T>>(
     }
 
     let standard_normal = Normal::new(0.0, 1.0)?;
-    let z_scores: Vec<T> = iter_if_parallel!(&sorted_data).map(|&x| (x - mean) / std_dev).collect();
-    let logp1: Vec<T> = iter_if_parallel!(&z_scores)
-        .map(|&z| T::from(standard_normal.cdf(z.to_f64().unwrap())).unwrap().ln())
-        .collect();
 
-    let logp2: Vec<T> = iter_if_parallel!(&z_scores)
-        .rev() // Can't easily parallelize rev() directly without collect, but rev is fast
-        .map(|&z| T::from(standard_normal.sf(z.to_f64().unwrap())).unwrap().ln())
-        .collect();
+    #[cfg(feature = "parallel")]
+    let h_sum = (0..n)
+        .into_par_iter()
+        .map(|i| {
+            let z_i = (sorted_data[i] - mean) / std_dev;
+            let z_rev = (sorted_data[n - 1 - i] - mean) / std_dev;
+            let lp1 = T::from(standard_normal.cdf(z_i.to_f64().unwrap())).unwrap().ln();
+            let lp2 = T::from(standard_normal.sf(z_rev.to_f64().unwrap())).unwrap().ln();
+            let i_t = T::from(i + 1).unwrap();
+            (T::from(2.0).unwrap() * i_t - T::one()) * (lp1 + lp2)
+        })
+        .sum::<T>();
 
+    #[cfg(not(feature = "parallel"))]
     let h_sum = (0..n)
         .map(|i| {
+            let z_i = (sorted_data[i] - mean) / std_dev;
+            let z_rev = (sorted_data[n - 1 - i] - mean) / std_dev;
+            let lp1 = T::from(standard_normal.cdf(z_i.to_f64().unwrap())).unwrap().ln();
+            let lp2 = T::from(standard_normal.sf(z_rev.to_f64().unwrap())).unwrap().ln();
             let i_t = T::from(i + 1).unwrap();
-            (T::from(2.0).unwrap() * i_t - T::one()) * (logp1[i] + logp2[i])
+            (T::from(2.0).unwrap() * i_t - T::one()) * (lp1 + lp2)
         })
-        .fold(T::zero(), |acc, val| acc + val);
+        .sum::<T>();
 
     let a = -n_t - h_sum / n_t;
     let aa = (T::one() + T::from(0.75).unwrap() / n_t + T::from(2.25).unwrap() / n_t.powi(2)) * a;

--- a/src/methods/dagostino_k_squared.rs
+++ b/src/methods/dagostino_k_squared.rs
@@ -64,15 +64,26 @@ pub fn dagostino_k_squared<T: Float, I: IntoIterator<Item = T>>(
     let n_t = T::from(n).unwrap();
     let mean = iter_if_parallel!(&data).copied().sum::<T>() / n_t;
 
-    let deviations: Vec<T> = iter_if_parallel!(&data).map(|&x| x - mean).collect();
-    let sum_sq_devs = iter_if_parallel!(&deviations).map(|&d| d.powi(2)).sum::<T>();
+    #[cfg(feature = "parallel")]
+    let (sum_sq_devs, m3_sum) = data
+        .par_iter()
+        .map(|&x| {
+            let d = x - mean;
+            (d.powi(2), d.powi(3))
+        })
+        .reduce(|| (T::zero(), T::zero()), |a, b| (a.0 + b.0, a.1 + b.1));
+
+    #[cfg(not(feature = "parallel"))]
+    let (sum_sq_devs, m3_sum) = data.iter().fold((T::zero(), T::zero()), |(s2, s3), &x| {
+        let d = x - mean;
+        (s2 + d.powi(2), s3 + d.powi(3))
+    });
 
     if sum_sq_devs < T::epsilon() {
         return Err(Error::ZeroRange);
     }
 
-    // Calculate skewness (s3)
-    let m3 = iter_if_parallel!(&deviations).map(|&d| d.powi(3)).sum::<T>() / n_t;
+    let m3 = m3_sum / n_t;
     let m2 = sum_sq_devs / n_t;
     let s3 = m3 / m2.powf(T::from(1.5).unwrap());
 

--- a/src/methods/jarque_bera.rs
+++ b/src/methods/jarque_bera.rs
@@ -54,15 +54,30 @@ pub fn jarque_bera<T: Float, I: IntoIterator<Item = T>>(data: I) -> Result<Compu
 
     let n_t = T::from(n).unwrap();
     let mean = iter_if_parallel!(&data).copied().sum::<T>() / n_t;
-    let deviations: Vec<T> = iter_if_parallel!(&data).map(|&x| x - mean).collect();
-    let m2 = iter_if_parallel!(&deviations).map(|&d| d.powi(2)).sum::<T>() / n_t;
+
+    #[cfg(feature = "parallel")]
+    let (m2_sum, m3_sum, m4_sum) = data
+        .par_iter()
+        .map(|&x| {
+            let d = x - mean;
+            (d.powi(2), d.powi(3), d.powi(4))
+        })
+        .reduce(|| (T::zero(), T::zero(), T::zero()), |a, b| (a.0 + b.0, a.1 + b.1, a.2 + b.2));
+
+    #[cfg(not(feature = "parallel"))]
+    let (m2_sum, m3_sum, m4_sum) =
+        data.iter().fold((T::zero(), T::zero(), T::zero()), |(m2, m3, m4), &x| {
+            let d = x - mean;
+            (m2 + d.powi(2), m3 + d.powi(3), m4 + d.powi(4))
+        });
+
+    let m2 = m2_sum / n_t;
+    let m3 = m3_sum / n_t;
+    let m4 = m4_sum / n_t;
 
     if m2 < T::epsilon() {
         return Err(Error::ZeroRange);
     }
-
-    let m3 = iter_if_parallel!(&deviations).map(|&d| d.powi(3)).sum::<T>() / n_t;
-    let m4 = iter_if_parallel!(&deviations).map(|&d| d.powi(4)).sum::<T>() / n_t;
 
     let skewness = m3 / m2.powf(T::from(1.5).unwrap());
     let kurtosis = m4 / m2.powi(2);

--- a/src/methods/lilliefors.rs
+++ b/src/methods/lilliefors.rs
@@ -62,20 +62,31 @@ pub fn lilliefors<T: Float, I: IntoIterator<Item = T>>(data: I) -> Result<Comput
     }
 
     let standard_normal = Normal::new(0.0, 1.0)?;
-    let p_values: Vec<T> = iter_if_parallel!(&sorted_data)
-        .map(|&x| {
+
+    #[cfg(feature = "parallel")]
+    let (d_plus, d_minus) = (0..n)
+        .into_par_iter()
+        .map(|i| {
+            let x = sorted_data[i];
             let z = (x - mean) / std_dev;
-            T::from(standard_normal.cdf(z.to_f64().unwrap())).unwrap()
+            let p = T::from(standard_normal.cdf(z.to_f64().unwrap())).unwrap();
+            let dp = T::from((i + 1) as f64 / n as f64).unwrap() - p;
+            let dm = p - T::from(i as f64 / n as f64).unwrap();
+            (dp, dm)
         })
-        .collect();
+        .reduce(|| (T::neg_infinity(), T::neg_infinity()), |a, b| (a.0.max(b.0), a.1.max(b.1)));
 
-    let d_plus = (0..n)
-        .map(|i| T::from((i + 1) as f64 / n as f64).unwrap() - p_values[i])
-        .fold(T::neg_infinity(), num_traits::Float::max);
-
-    let d_minus = (0..n)
-        .map(|i| p_values[i] - T::from(i as f64 / n as f64).unwrap())
-        .fold(T::neg_infinity(), num_traits::Float::max);
+    #[cfg(not(feature = "parallel"))]
+    let (d_plus, d_minus) = (0..n)
+        .map(|i| {
+            let x = sorted_data[i];
+            let z = (x - mean) / std_dev;
+            let p = T::from(standard_normal.cdf(z.to_f64().unwrap())).unwrap();
+            let dp = T::from((i + 1) as f64 / n as f64).unwrap() - p;
+            let dm = p - T::from(i as f64 / n as f64).unwrap();
+            (dp, dm)
+        })
+        .fold((T::neg_infinity(), T::neg_infinity()), |a, b| (a.0.max(b.0), a.1.max(b.1)));
 
     let k = d_plus.max(d_minus);
 

--- a/src/methods/multivariate/henze_wagner.rs
+++ b/src/methods/multivariate/henze_wagner.rs
@@ -144,18 +144,18 @@ fn calculate_hw_statistic<T: Float + RealField>(
     let d_f64 = d as f64;
     let b: f64 = 1.0;
     let b_sq = b * b;
-    let big_d_matrix = &x_centered * x_s_inv.transpose();
 
     #[cfg(feature = "parallel")]
     let sum_exp_djk: f64 = (0..n)
         .into_par_iter()
         .map(|j| {
             let dj = d_diag[j].to_f64().unwrap();
+            let row_j = x_centered.row(j);
             let mut local_sum = 0.0;
 
-            for k in 0..n {
-                let dk = d_diag[k].to_f64().unwrap();
-                let d_cross = big_d_matrix[(j, k)].to_f64().unwrap();
+            for (k, item) in d_diag.iter().enumerate().take(n) {
+                let dk = item.to_f64().unwrap();
+                let d_cross = row_j.dot(&x_s_inv.row(k)).to_f64().unwrap();
                 let d_jk = dj + dk - 2.0 * d_cross;
 
                 local_sum += (-b_sq / 2.0 * d_jk).exp();
@@ -169,11 +169,12 @@ fn calculate_hw_statistic<T: Float + RealField>(
     let sum_exp_djk: f64 = (0..n)
         .map(|j| {
             let dj = d_diag[j].to_f64().unwrap();
+            let row_j = x_centered.row(j);
             let mut local_sum = 0.0;
 
-            for k in 0..n {
-                let dk = d_diag[k].to_f64().unwrap();
-                let d_cross = big_d_matrix[(j, k)].to_f64().unwrap();
+            for (k, item) in d_diag.iter().enumerate().take(n) {
+                let dk = item.to_f64().unwrap();
+                let d_cross = row_j.dot(&x_s_inv.row(k)).to_f64().unwrap();
                 let d_jk = dj + dk - 2.0 * d_cross;
 
                 local_sum += (-b_sq / 2.0 * d_jk).exp();

--- a/src/methods/multivariate/henze_zirkler.rs
+++ b/src/methods/multivariate/henze_zirkler.rs
@@ -172,18 +172,18 @@ fn calculate_hz_statistic<T: Float + RealField>(
     let exponent = 1.0 / (d_f64 + 4.0);
     let b = (1.0 / SQRT_2) * ((2.0 * d_f64 + 1.0) / 4.0).powf(exponent) * n_f64.powf(exponent);
     let b_sq = b * b;
-    let big_d_matrix = &x_centered * x_s_inv.transpose(); // (n x n) matrix of D_ij
 
     #[cfg(feature = "parallel")]
     let sum_exp_djk: f64 = (0..n)
         .into_par_iter()
         .map(|i| {
             let di = d_sq[i].to_f64().unwrap();
+            let row_i = x_centered.row(i);
             let mut local_sum = 0.0;
 
-            for j in 0..n {
-                let dj = d_sq[j].to_f64().unwrap();
-                let dij = big_d_matrix[(i, j)].to_f64().unwrap();
+            for (j, item) in d_sq.iter().enumerate().take(n) {
+                let dj = item.to_f64().unwrap();
+                let dij = row_i.dot(&x_s_inv.row(j)).to_f64().unwrap();
                 let dist_sq = di + dj - 2.0 * dij;
 
                 local_sum += (-b_sq / 2.0 * dist_sq).exp();
@@ -197,11 +197,12 @@ fn calculate_hz_statistic<T: Float + RealField>(
     let sum_exp_djk: f64 = (0..n)
         .map(|i| {
             let di = d_sq[i].to_f64().unwrap();
+            let row_i = x_centered.row(i);
             let mut local_sum = 0.0;
 
-            for j in 0..n {
-                let dj = d_sq[j].to_f64().unwrap();
-                let dij = big_d_matrix[(i, j)].to_f64().unwrap();
+            for (j, item) in d_sq.iter().enumerate().take(n) {
+                let dj = item.to_f64().unwrap();
+                let dij = row_i.dot(&x_s_inv.row(j)).to_f64().unwrap();
                 let dist_sq = di + dj - 2.0 * dij;
 
                 local_sum += (-b_sq / 2.0 * dist_sq).exp();

--- a/src/methods/multivariate/mardia.rs
+++ b/src/methods/multivariate/mardia.rs
@@ -163,10 +163,38 @@ fn calculate_mardia_statistics<T: Float + RealField>(
             .map_err(|_| Error::Other("Failed to compute pseudoinverse".into()))?
     };
 
-    let d_mat = &x_centered * &s_inv * x_centered.transpose();
-    let sum_d_cubed: f64 = d_mat.iter().map(|&v| v.to_f64().unwrap().powi(3)).sum();
+    let x_s_inv = &x_centered * &s_inv;
+
+    #[cfg(feature = "parallel")]
+    let (sum_d_cubed, sum_diag_sq) = (0..n)
+        .into_par_iter()
+        .map(|i| {
+            let row_i = x_centered.row(i);
+            let d_ii = row_i.dot(&x_s_inv.row(i)).to_f64().unwrap();
+            let mut sum_cubed = 0.0;
+            for j in 0..n {
+                let d_ij = row_i.dot(&x_s_inv.row(j)).to_f64().unwrap();
+                sum_cubed += d_ij.powi(3);
+            }
+            (sum_cubed, d_ii.powi(2))
+        })
+        .reduce(|| (0.0, 0.0), |a, b| (a.0 + b.0, a.1 + b.1));
+
+    #[cfg(not(feature = "parallel"))]
+    let (sum_d_cubed, sum_diag_sq) = (0..n)
+        .map(|i| {
+            let row_i = x_centered.row(i);
+            let d_ii = row_i.dot(&x_s_inv.row(i)).to_f64().unwrap();
+            let mut sum_cubed = 0.0;
+            for j in 0..n {
+                let d_ij = row_i.dot(&x_s_inv.row(j)).to_f64().unwrap();
+                sum_cubed += d_ij.powi(3);
+            }
+            (sum_cubed, d_ii.powi(2))
+        })
+        .fold((0.0, 0.0), |a, b| (a.0 + b.0, a.1 + b.1));
+
     let g1p = sum_d_cubed / (n_f64 * n_f64);
-    let sum_diag_sq: f64 = d_mat.diagonal().iter().map(|&v| v.to_f64().unwrap().powi(2)).sum();
     let g2p = sum_diag_sq / n_f64;
     let k_const = ((p_f64 + 1.0) * (n_f64 + 1.0) * (n_f64 + 3.0))
         / (n_f64 * ((n_f64 + 1.0) * (p_f64 + 1.0) - 6.0));

--- a/src/methods/pearson_chi_squared.rs
+++ b/src/methods/pearson_chi_squared.rs
@@ -75,15 +75,40 @@ pub fn pearson_chi_squared<T: Float, I: IntoIterator<Item = T>>(
 
     // Bin the data based on the normal distribution's CDF.
     let normal_dist = Normal::new(mean.to_f64().unwrap(), std_dev.to_f64().unwrap())?;
-    let mut counts = vec![0; num_classes];
 
-    for &x in &clean_data {
+    #[cfg(feature = "parallel")]
+    let counts = clean_data
+        .par_iter()
+        .fold(
+            || vec![0usize; num_classes],
+            |mut local_counts, &x| {
+                let p = normal_dist.cdf(x.to_f64().unwrap());
+                let bin_num = (1.0 + num_classes_t.to_f64().unwrap() * p).floor() as usize;
+                if bin_num >= 1 && bin_num <= num_classes {
+                    local_counts[bin_num - 1] += 1; // Convert 1-based bin to 0-based index.
+                }
+                local_counts
+            },
+        )
+        .reduce(
+            || vec![0usize; num_classes],
+            |mut a, b| {
+                for (i, &v) in b.iter().enumerate() {
+                    a[i] += v;
+                }
+                a
+            },
+        );
+
+    #[cfg(not(feature = "parallel"))]
+    let counts = clean_data.iter().fold(vec![0usize; num_classes], |mut local_counts, &x| {
         let p = normal_dist.cdf(x.to_f64().unwrap());
         let bin_num = (1.0 + num_classes_t.to_f64().unwrap() * p).floor() as usize;
         if bin_num >= 1 && bin_num <= num_classes {
-            counts[bin_num - 1] += 1; // Convert 1-based bin to 0-based index.
+            local_counts[bin_num - 1] += 1;
         }
-    }
+        local_counts
+    });
 
     // Calculate the chi-squared statistic.
     let expected_count = n_t / num_classes_t;

--- a/tests/accuracy.rs
+++ b/tests/accuracy.rs
@@ -1,6 +1,3 @@
-//! Integration tests for the energy test is flaky due to differences in integration algorithms
-//! between R and Rust. Thus, the need for retries.
-
 use std::env;
 use std::fs::remove_dir_all;
 use std::io::Write;
@@ -456,57 +453,6 @@ macro_rules! gen_accuracy_tests {
                 assert_float_absolute_eq!(r_norm_p, norm_result.p_value);
                 assert_float_absolute_eq!(r_unif_stat, unif_result.statistic);
                 assert_float_absolute_eq!(r_unif_p, unif_result.p_value);
-            }
-
-            #[test]
-            fn [<energy_test_asymptotic_accuracy_ $n>]() {
-                install_r_packages();
-
-                let norm = sample_norm_data($n);
-                let unif = sample_unif_data($n);
-
-                let norm_r = data_to_r(&norm);
-                let unif_r = data_to_r(&unif);
-
-                let r_code = formatdoc! {"
-                    library(energy)
-
-                    norm <- {norm}
-                    unif <- {unif}
-
-                    norm_result <- normal.test(norm, method = \"limit\")
-                    unif_result <- normal.test(unif, method = \"limit\")
-
-                    print(paste(norm_result$statistic, norm_result$p.value))
-                    print(paste(unif_result$statistic, unif_result$p.value))
-                ",
-                    norm = norm_r,
-                    unif = unif_r
-                };
-
-                let [(r_norm_stat, r_norm_p), (r_unif_stat, r_unif_p), ..] = execute_r(r_code)
-                    .split("\n")
-                    .map(|line| {
-                        let values = line.split_whitespace().skip(1).collect::<Vec<_>>();
-
-                        (
-                            f64::from_str(&values[0].replace('"', "")).unwrap(),
-                            f64::from_str(&values[1].replace('"', "")).unwrap(),
-                        )
-                    })
-                    .collect::<Vec<_>>()[..]
-                else {
-                    unreachable!()
-                };
-
-                let norm_result = energy_test(norm, EnergyTestMethod::Asymptotic).unwrap();
-                let unif_result = energy_test(unif, EnergyTestMethod::Asymptotic).unwrap();
-
-                // Integral approximation
-                assert_float_absolute_eq!(r_norm_stat, norm_result.statistic, 1e-3);
-                assert_float_absolute_eq!(r_norm_p, norm_result.p_value, 1e-3);
-                assert_float_absolute_eq!(r_unif_stat, unif_result.statistic, 1e-3);
-                assert_float_absolute_eq!(r_unif_p, unif_result.p_value, 1e-3);
             }
 
             #[test]


### PR DESCRIPTION
Currently, many tests create intermediate allocations for multiple steps, followed by sequential folds, or even worse, allocate $O(n^2)$ matrices in memory to compute distances for multivariate tests.

These have been improved by eliminating the intermediate vector allocations for computing standardized variables, percentiles, log probabilities, and inner loops.

For `henze_zirkler`, `henze_wagner`, and `mardia`, we stop calculating `d_mat = X * S_inv * X.T` which allocates an $n \times n$ matrix (causing heavy memory use and cache misses for large $n$). Instead, we dynamically compute row dot products inside the parallel loop.